### PR TITLE
Fix typo in cases.ejs

### DIFF
--- a/src/views/sections/cases.ejs
+++ b/src/views/sections/cases.ejs
@@ -26,7 +26,7 @@
 		</div>
 		<div class="col-8 col-s-12">
 			<h3>Protecting your privacy</h3>
-			<p>Aegon processes lots of personal data. From your address, income and credit score, to your passport, pension and family composition. All that data has to be stored in a secure manner, but also has to be accessible to our software. As a customer, you must of course have insight into who is using your personal data – and you must be able to block this access if you so desire. If you pick our case, we expect you and your tem to use Amazon Web Services to create a secure upload portal that that complies with the Dutch "Wet Bescherming Persoonsgegevens" or personal data laws.</p>
+			<p>Aegon processes lots of personal data. From your address, income and credit score, to your passport, pension and family composition. All that data has to be stored in a secure manner, but also has to be accessible to our software. As a customer, you must of course have insight into who is using your personal data – and you must be able to block this access if you so desire. If you pick our case, we expect you and your team to use Amazon Web Services to create a secure upload portal that that complies with the Dutch "Wet Bescherming Persoonsgegevens" or personal data laws.</p>
 		</div>
 	</div>
 	<div class="row case" id="volksbank">


### PR DESCRIPTION
In the case of Aegon, 'team' is spelled 'tem', which I think is a typo.