### PR TITLE
Docker multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ COPY . .
 RUN yarn
 RUN yarn build
 
-FROM nginx:alpine
-COPY --from=builder /src/build /usr/share/nginx/html
+FROM wisvch/nginx
+COPY --from=builder /src/build/ /srv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
+FROM node:carbon AS builder
+WORKDIR /src
+COPY . .
+RUN yarn
+RUN yarn build
+
 FROM nginx:alpine
-COPY . /react
-RUN apk update
-RUN apk add yarn
-RUN cd /react && yarn && yarn build
-RUN mv /react/build/* /usr/share/nginx/html
+COPY --from=builder /src/build /usr/share/nginx/html

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hackdelft-web",
   "version": "0.1.0",
   "private": true,
-  "homepage": "http://www.hackdelft.com",
+  "homepage": "https://www.hackdelft.com",
   "dependencies": {
     "axios": "^0.17.1",
     "material-ui": "^1.0.0-beta.34",


### PR DESCRIPTION
Use [Docker multi-stage build](https://docs.docker.com/develop/develop-images/multistage-build/) to decrease image size from 512MB to 46MB.